### PR TITLE
Fix the validation error of output type

### DIFF
--- a/neptune-mcp-servers/neptune-memory/src/neptune_memory_mcp_server/server.py
+++ b/neptune-mcp-servers/neptune-memory/src/neptune_memory_mcp_server/server.py
@@ -74,7 +74,8 @@ def create_entities(entities: List[Entity]) -> str:
     Returns:
         str: Confirmation message indicating the result of the operation.
     """
-    return memory.create_entities(entities)
+    result = memory.create_entities(entities)
+    return f"Successfully created {len(result)} entities."
 
 
 @mcp.tool(name="create_relations",
@@ -89,7 +90,8 @@ def create_relations(relations: List[Relation]) -> str:
     Returns:
         str: Confirmation message indicating the result of the operation.
     """
-    return memory.create_relations(relations)
+    result = memory.create_relations(relations)
+    return f"Successfully created {len(result)} relations."
 
 
 @mcp.tool(name="read_memory",


### PR DESCRIPTION
*Issue #, if available:*
text:"Error executing tool create_entities: 1 validation error for create_entitiesOutput
result
  Input should be a valid string [type=string_type, input_value=[Entity(name='Application...助于负载均衡'])], input_type=list]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type"

*Description of changes:*
Fix the output type of mcp_tools(create_entities, create_relationships)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
